### PR TITLE
Fix for test files that caused build to fail + Dockerfile for easy build/run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ nb-configuration.xml
 .DS_Store
 logs/
 node/
+*.classpath
+*.project
+*.settings

--- a/doc/server.md
+++ b/doc/server.md
@@ -1,5 +1,9 @@
 # Server documentation
 
+## Quickstart with Docker
+
+If you have Docker installed (if not, you can find how to do so [here](https://docs.docker.com/engine/installation/)), and don't want to mess with your pre-existing dev environment, you may prefer to check [the Docker build and run process](../org.occiware.mart.jetty/README.md).
+
 ## Build the application
 Go to the application's directory and then:
 <pre>

--- a/org.occiware.mart.jetty/Dockerfile
+++ b/org.occiware.mart.jetty/Dockerfile
@@ -1,0 +1,17 @@
+# Use an official openjdk base image
+FROM openjdk:8
+
+# Set the working directory to /app
+WORKDIR /app
+
+# Copy the appropriate current directory contents into the container at /app
+COPY target/org.occiware.mart.jetty-1.0-SNAPSHOT-jar-with-dependencies.jar /app/org.occiware.mart.jetty-1.0-SNAPSHOT-jar-with-dependencies.jar
+COPY martserver.config /app/martserver.config
+
+# Make ports 8081 (http) and 8181 (https) available to the world outside this container
+EXPOSE 8081
+EXPOSE 8181
+
+# Run app when the container launches
+CMD ["java", "-jar", "org.occiware.mart.jetty-1.0-SNAPSHOT-jar-with-dependencies.jar", "martserver.config"]
+

--- a/org.occiware.mart.jetty/README.md
+++ b/org.occiware.mart.jetty/README.md
@@ -1,0 +1,31 @@
+## How to build and run it locally
+
+If you want to build a jar with all the dependencies in order to dockerize do :
+
+```bash
+mvn clean compile assembly:single
+```
+
+To launch the jar, go to the target directory and execute it with java (with the config as first parameter) :
+
+```bash
+cd target/
+java -jar org.occiware.mart.jetty-1.0-SNAPSHOT-jar-with-dependencies.jar ../martserver.config
+```
+
+To check if everything is working properly, execute the following request :
+
+```bash
+curl -v -X GET http://localhost:8081/.well-known/org/ogf/occi/-/ -H "accept: application/json"
+```
+
+## Creating a docker image
+
+If you have Docker installed (if not, you can find how to do so [here](https://docs.docker.com/engine/installation/)), you may want to create a docker container.
+
+Supposing you are currently in this README.md's directory, that is to say, "org.occiware.mart.jetty", and that you have followed all the previous steps so that you built a jar with all the dependencies, do :
+
+``` bash
+sudo docker build -t mart-server .
+sudo docker run -p 8081:8081 mart-server
+```

--- a/org.occiware.mart.jetty/martserver.config
+++ b/org.occiware.mart.jetty/martserver.config
@@ -1,0 +1,2 @@
+server.port=8081
+server.https.port=8181

--- a/org.occiware.mart.jetty/pom.xml
+++ b/org.occiware.mart.jetty/pom.xml
@@ -50,6 +50,19 @@
                     <mainClass>org.occiware.mart.jetty.MartServer</mainClass>
                 </configuration>
             </plugin>
+            <plugin>
+              <artifactId>maven-assembly-plugin</artifactId>
+              <configuration>
+                <archive>
+                  <manifest>
+                    <mainClass>org.occiware.mart.jetty.MartServer</mainClass>
+                  </manifest>
+                </archive>
+                <descriptorRefs>
+                  <descriptorRef>jar-with-dependencies</descriptorRef>
+                </descriptorRefs>
+              </configuration>
+            </plugin>
         </plugins>
 
     </build>

--- a/org.occiware.mart.jetty/src/test/java/org/occiware/mart/jetty/integration/ServerTest.java
+++ b/org.occiware.mart.jetty/src/test/java/org/occiware/mart/jetty/integration/ServerTest.java
@@ -21,24 +21,20 @@ package org.occiware.mart.jetty.integration;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.ContentResponse;
 import org.eclipse.jetty.http.HttpMethod;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.servlet.ServletContextHandler;
-import org.eclipse.jetty.servlet.ServletHandler;
-import org.eclipse.jetty.servlet.ServletHolder;
-import org.eclipse.jetty.util.UrlEncoded;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.occiware.mart.jetty.MartServer;
-import org.occiware.mart.server.parser.json.JsonOcciParser;
 import org.occiware.mart.server.utils.Constants;
-import org.occiware.mart.servlet.MainServlet;
 
 import javax.servlet.http.HttpServletResponse;
 import java.io.File;
-import java.nio.charset.Charset;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import static org.junit.Assert.*;
 
@@ -126,8 +122,13 @@ public class ServerTest {
      * @return
      */
     private File getResourceInputFile(String path) {
-        File inputJsonFile = new File(this.getClass().getResource(path).getFile());
-        System.out.println(inputJsonFile.getAbsolutePath());
+        File inputJsonFile = null;
+        try {
+            inputJsonFile = new File(new URI(this.getClass().getResource(path).toString()));
+            System.out.println(inputJsonFile.getAbsolutePath());
+        } catch (URISyntaxException e) {
+        	Logger.getLogger(ServerTest.class.getName()).log(Level.SEVERE, null, e);
+        }
         return inputJsonFile;
     }
 

--- a/org.occiware.mart.server/src/test/java/org/occiware/mart/server/parser/JsonParserTest.java
+++ b/org.occiware.mart.server/src/test/java/org/occiware/mart/server/parser/JsonParserTest.java
@@ -31,6 +31,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -123,8 +125,13 @@ public class JsonParserTest {
 
 
     private File getJsonResourceInput(String path) {
-        File inputJsonFile = new File(this.getClass().getResource(path).getFile());
-        System.out.println(inputJsonFile.getAbsolutePath());
+        File inputJsonFile = null;
+        try {
+            inputJsonFile = new File(new URI(this.getClass().getResource(path).toString()));
+            System.out.println(inputJsonFile.getAbsolutePath());
+        } catch (URISyntaxException e) {
+            Logger.getLogger(JsonParserTest.class.getName()).log(Level.SEVERE, null, e);
+        }
         return inputJsonFile;
     }
 }

--- a/org.occiware.mart.servlet/src/test/java/org/occiware/mart/servlet/integration/MainServletIT.java
+++ b/org.occiware.mart.servlet/src/test/java/org/occiware/mart/servlet/integration/MainServletIT.java
@@ -36,7 +36,12 @@ import javax.servlet.http.HttpServletResponse;
 
 import static org.junit.Assert.*;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.util.List;
 
@@ -359,7 +364,7 @@ public class MainServletIT {
         response = executeQuery(httpMethod, "http://localhost:9090/compute/", HttpServletResponse.SC_OK,
                 null,
                 "Get resource collection for the compute kind , location : /compute/ ", Constants.MEDIA_TYPE_JSON, Constants.MEDIA_TYPE_JSON);
-        
+
         // Get request on /compute/ using text/uri-list.
         response = executeQuery(httpMethod, "http://localhost:9090/compute/", HttpServletResponse.SC_OK,
                 null,
@@ -551,8 +556,13 @@ public class MainServletIT {
      * @return
      */
     private File getResourceInputFile(String path) {
-        File inputJsonFile = new File(this.getClass().getResource(path).getFile());
-        System.out.println(inputJsonFile.getAbsolutePath());
+        File inputJsonFile = null;
+        try {
+            inputJsonFile = new File(new URI(this.getClass().getResource(path).toString()));
+            System.out.println(inputJsonFile.getAbsolutePath());
+        } catch (URISyntaxException e) {
+            Logger.getLogger(MainServletIT.class.getName()).log(Level.SEVERE, null, e);
+        }
         return inputJsonFile;
     }
 


### PR DESCRIPTION
Fix for the reading of test files that caused the build to fail: when one of the parent folders for the project had special characters or spaces in its name, the build would fail because it couldn't find the test files. This has been fixed by creating a URI object that automatically formats the path correctly, whatever the circumstances.

Also updated the .gitignore so that local eclipse-specific files are not considered by git anymore.